### PR TITLE
[AT-3730] Add LegacyTrust::Instruction::FiatDeposit.create

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    legacy-trust-api (0.1.0)
+    legacy-trust-api (0.1.1)
       awrence (~> 1.1.0)
       oauth2 (~> 1.4.0)
       plissken (~> 1.3.0)

--- a/README.md
+++ b/README.md
@@ -22,14 +22,15 @@ Or install it yourself as:
 
 ## Usage
 
-Setup OAuth2 credentials `client_id` and `client_secret` before your first use.
+### OAuth2 authentication
+Setup OAuth2 credentials `oauth_client_id` and `oauth_client_secret` before your first use. These are mandatory to establish authentication with LegacyTrust API. In case these keys are missing or invalid, you should get `LegacyTrust::SetupError`.
 
 Example:
 ```ruby
 require 'legacy_trust'
 
-LegacyTrust.client_id = 'your-client-id'
-Legacytrust.client_secret = 'your-client-secret'
+LegacyTrust.oauth_client_id = 'your-client-id'
+Legacytrust.oauth_client_secret = 'your-client-secret'
 
 LegacyTrust::Currency.fetch_all(params: { currency_class: 'Fiat' })
 ```
@@ -47,6 +48,19 @@ gives the following result:
    {:symbol=>"TYTYYY", :name=>"ttyjnljnlnknjjk jk kj lj jk j k l ", :class=>"Fiat", :decimal_places=>2},
    {:symbol=>"USD", :name=>"US Dollar", :class=>"Fiat", :decimal_places=>2}],
  @status=200>
+```
+
+### Global API settings
+In case that your API integration is not based on multiple client ids or service account ids, there is an option to set up `global_client_id` and `global_service_account_id` so there is no need to attach them to each API request execution.
+
+Example:
+```ruby
+require 'legacy_trust'
+
+LegacyTrust.global_client_id = 'your-client-id'
+Legacytrust.global_service_account_id = 'your-service-account-id'
+
+LegacyTrust::Instruction::FiatDeposit.create(body: { client_bank_account_id: 36, amount: 100.5 })
 ```
 
 ## Contributing

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -1,3 +1,8 @@
 ---
-CLIENT_ID: --- SOME ID ---
-CLIENT_SECRET: --- SOME SECRET ---
+# OAuth Authorization keys [Mandatory]
+OAUTH_CLIENT_ID: --- SOME ID ---
+OAUTH_CLIENT_SECRET: --- SOME SECRET ---
+
+# API global keys [Optional]
+GLOBAL_CLIENT_ID: --- SOME ID ---
+GLOBAL_SERVICE_ACCOUNT_ID: --- SOME ID ---

--- a/lib/legacy_trust.rb
+++ b/lib/legacy_trust.rb
@@ -4,6 +4,7 @@ require 'legacy_trust/result'
 require 'legacy_trust/request_error'
 require 'legacy_trust/setup_error'
 require 'legacy_trust/currency'
+require 'legacy_trust/instruction/fiat_deposit'
 require 'awrence'
 require 'oauth2'
 require 'plissken'
@@ -11,7 +12,10 @@ require 'plissken'
 # LegacyTrust API wrapper
 module LegacyTrust
   class << self
-    attr_accessor :client_id, :client_secret
+    # OAuth authentication keys
+    attr_accessor :oauth_client_id, :oauth_client_secret
+    # API global keys
+    attr_accessor :global_client_id, :global_service_account_id
 
     ACCESS_TOKEN_BASE_URL = 'https://auth.smarttrust.welton.ee'
     ACCESS_TOKEN_ENDPOINT = 'connect/token'
@@ -39,13 +43,27 @@ module LegacyTrust
       handle_request_error(e)
     end
 
+    #
+    # - +opts+: hash that may contain :params, :body and :headers
+    #
+    # Options Hash (opts):
+    #  - :params (Hash) - additional query parameters for the URL of the request
+    #  - :body (Hash, String) - the body of the request
+    #  - :headers (Hash) - http request headers
+    #
+    def attach_global_service_account_id_to_body(opts = {})
+      init_body = {}
+      init_body.merge!(service_account_id: global_service_account_id) if global_service_account_id
+      opts.merge(body: init_body.merge(opts[:body] || {}))
+    end
+
     private
 
     def oauth_token
       validate_setup!
       client = OAuth2::Client.new(
-        client_id,
-        client_secret,
+        oauth_client_id,
+        oauth_client_secret,
         site: ACCESS_TOKEN_BASE_URL,
         token_url: ACCESS_TOKEN_ENDPOINT
       )
@@ -71,23 +89,54 @@ module LegacyTrust
     end
 
     def validate_setup!
-      return if client_id && client_secret
+      return if oauth_client_id && oauth_client_secret
 
-      raise LegacyTrust::SetupError, 'client_id or client_secret is missing'
+      raise LegacyTrust::SetupError, 'oauth_client_id or oauth_client_secret is missing'
     end
 
     def map_options(opts = {})
-      mapped_opts = {}
+      mapped_opts = initial_opts
       %i[params body headers].each do |key|
-        next unless opts[key]
+        next unless opts[key] || mapped_opts[key]
 
-        mapped_opts.merge!(key => opts[key].to_camelback_keys)
+        option_hash = (mapped_opts[key] || {}).merge(opts[key] || {})
+        mapped_opts.merge!(key => option_hash.to_camelback_keys)
       end
+      mapped_opts = stringify_header_values(mapped_opts)
+      mapped_opts = convert_body_to_json(mapped_opts)
       mapped_opts
     end
 
+    def initial_headers
+      init = { 'content-type': 'application/json' }
+      init.merge!(client_id: global_client_id) if global_client_id
+      init
+    end
+
+    def initial_opts
+      {
+        headers: initial_headers
+      }
+    end
+
     def map_response_body(body)
+      return body unless body.is_a?(Hash) || body.is_a?(Array)
+
       body.to_snake_keys
+    end
+
+    def stringify_header_values(mapped_opts)
+      return mapped_opts unless mapped_opts[:headers]
+
+      mapped_opts[:headers] = mapped_opts[:headers].transform_values(&:to_s)
+      mapped_opts
+    end
+
+    def convert_body_to_json(mapped_opts)
+      return mapped_opts unless mapped_opts[:body]
+
+      mapped_opts[:body] = mapped_opts[:body].to_json
+      mapped_opts
     end
   end
 end

--- a/lib/legacy_trust/instruction/fiat_deposit.rb
+++ b/lib/legacy_trust/instruction/fiat_deposit.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module LegacyTrust
+  # Describes Instructions namespace
+  module Instruction
+    # Describes FiatDeposit resources
+    module FiatDeposit
+      class << self
+        #
+        # GET /instructions/deposits-fiat
+        #
+        # - +opts+: hash that allows to enter :params, :body and :headers
+        #
+        # Options Hash (opts):
+        #  - headers: (Hash)
+        #   - :client_id (Integer)
+        #  - body: (Hash)
+        #   - service_account_id (Integer)
+        #   - client_bank_account_id (Integer)
+        #   - amount (Decimal)
+        #   - source_of_funds (String) [Optional]
+        #   - purpose_of_payment (String) [Optional]
+        #   - supporting_document (Hash) [Optional]
+        #
+        def create(opts = {})
+          opts = LegacyTrust.attach_global_service_account_id_to_body(opts)
+          LegacyTrust.request(:post, '/instructions/deposits-fiat', opts)
+        end
+      end
+    end
+  end
+end

--- a/lib/legacy_trust/version.rb
+++ b/lib/legacy_trust/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LegacyTrust
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end

--- a/spec/fixtures/vcr_cassettes/LegacyTrustCurrency/FetchAll/WhenFilteringByClass/Result/contains_items_from_selected_class.yml
+++ b/spec/fixtures/vcr_cassettes/LegacyTrustCurrency/FetchAll/WhenFilteringByClass/Result/contains_items_from_selected_class.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://auth.smarttrust.welton.ee/connect/token
     body:
       encoding: UTF-8
-      string: client_id=config_env['CLIENT_ID']&client_secret=config_env['CLIENT_SECRET']&grant_type=client_credentials&scope=PartnerApi
+      string: client_id=config_env['OAUTH_CLIENT_ID']&client_secret=config_env['OAUTH_CLIENT_SECRET']&grant_type=client_credentials&scope=PartnerApi
     headers:
       User-Agent:
       - Faraday v1.0.1

--- a/spec/fixtures/vcr_cassettes/LegacyTrustCurrency/FetchAll/WhenFilteringByClass/Result/contains_items_that_are_currencies.yml
+++ b/spec/fixtures/vcr_cassettes/LegacyTrustCurrency/FetchAll/WhenFilteringByClass/Result/contains_items_that_are_currencies.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://auth.smarttrust.welton.ee/connect/token
     body:
       encoding: UTF-8
-      string: client_id=config_env['CLIENT_ID']&client_secret=config_env['CLIENT_SECRET']&grant_type=client_credentials&scope=PartnerApi
+      string: client_id=config_env['OAUTH_CLIENT_ID']&client_secret=config_env['OAUTH_CLIENT_SECRET']&grant_type=client_credentials&scope=PartnerApi
     headers:
       User-Agent:
       - Faraday v1.0.1

--- a/spec/fixtures/vcr_cassettes/LegacyTrustCurrency/FetchAll/WhenFilteringByClass/Result/contains_number_of_items.yml
+++ b/spec/fixtures/vcr_cassettes/LegacyTrustCurrency/FetchAll/WhenFilteringByClass/Result/contains_number_of_items.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://auth.smarttrust.welton.ee/connect/token
     body:
       encoding: UTF-8
-      string: client_id=config_env['CLIENT_ID']&client_secret=config_env['CLIENT_SECRET']&grant_type=client_credentials&scope=PartnerApi
+      string: client_id=config_env['OAUTH_CLIENT_ID']&client_secret=config_env['OAUTH_CLIENT_SECRET']&grant_type=client_credentials&scope=PartnerApi
     headers:
       User-Agent:
       - Faraday v1.0.1

--- a/spec/fixtures/vcr_cassettes/LegacyTrustCurrency/FetchAll/WhenFilteringByClass/returns_result.yml
+++ b/spec/fixtures/vcr_cassettes/LegacyTrustCurrency/FetchAll/WhenFilteringByClass/returns_result.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://auth.smarttrust.welton.ee/connect/token
     body:
       encoding: UTF-8
-      string: client_id=config_env['CLIENT_ID']&client_secret=config_env['CLIENT_SECRET']&grant_type=client_credentials&scope=PartnerApi
+      string: client_id=config_env['OAUTH_CLIENT_ID']&client_secret=config_env['OAUTH_CLIENT_SECRET']&grant_type=client_credentials&scope=PartnerApi
     headers:
       User-Agent:
       - Faraday v1.0.1

--- a/spec/fixtures/vcr_cassettes/LegacyTrustCurrency/FetchAll/WhenNoParams/Result/contains_items_that_are_currencies.yml
+++ b/spec/fixtures/vcr_cassettes/LegacyTrustCurrency/FetchAll/WhenNoParams/Result/contains_items_that_are_currencies.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://auth.smarttrust.welton.ee/connect/token
     body:
       encoding: UTF-8
-      string: client_id=config_env['CLIENT_ID']&client_secret=config_env['CLIENT_SECRET']&grant_type=client_credentials&scope=PartnerApi
+      string: client_id=config_env['OAUTH_CLIENT_ID']&client_secret=config_env['OAUTH_CLIENT_SECRET']&grant_type=client_credentials&scope=PartnerApi
     headers:
       User-Agent:
       - Faraday v1.0.1

--- a/spec/fixtures/vcr_cassettes/LegacyTrustCurrency/FetchAll/WhenNoParams/Result/contains_number_of_items.yml
+++ b/spec/fixtures/vcr_cassettes/LegacyTrustCurrency/FetchAll/WhenNoParams/Result/contains_number_of_items.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://auth.smarttrust.welton.ee/connect/token
     body:
       encoding: UTF-8
-      string: client_id=config_env['CLIENT_ID']&client_secret=config_env['CLIENT_SECRET']&grant_type=client_credentials&scope=PartnerApi
+      string: client_id=config_env['OAUTH_CLIENT_ID']&client_secret=config_env['OAUTH_CLIENT_SECRET']&grant_type=client_credentials&scope=PartnerApi
     headers:
       User-Agent:
       - Faraday v1.0.1

--- a/spec/fixtures/vcr_cassettes/LegacyTrustCurrency/FetchAll/WhenNoParams/returns_result.yml
+++ b/spec/fixtures/vcr_cassettes/LegacyTrustCurrency/FetchAll/WhenNoParams/returns_result.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: https://auth.smarttrust.welton.ee/connect/token
     body:
       encoding: UTF-8
-      string: client_id=config_env['CLIENT_ID']&client_secret=config_env['CLIENT_SECRET']&grant_type=client_credentials&scope=PartnerApi
+      string: client_id=config_env['OAUTH_CLIENT_ID']&client_secret=config_env['OAUTH_CLIENT_SECRET']&grant_type=client_credentials&scope=PartnerApi
     headers:
       User-Agent:
       - Faraday v1.0.1

--- a/spec/fixtures/vcr_cassettes/LegacyTrustInstructionFiatDeposit/Create/WhenInvalidParams/raises_error.yml
+++ b/spec/fixtures/vcr_cassettes/LegacyTrustInstructionFiatDeposit/Create/WhenInvalidParams/raises_error.yml
@@ -1,0 +1,106 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://auth.smarttrust.welton.ee/connect/token
+    body:
+      encoding: UTF-8
+      string: client_id=config_env['OAUTH_CLIENT_ID']&client_secret=config_env['OAUTH_CLIENT_SECRET']&grant_type=client_credentials&scope=PartnerApi
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 06 Oct 2020 17:24:26 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '1321'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-store, no-cache, max-age=0
+      Pragma:
+      - no-cache
+      Vary:
+      - Accept-Encoding
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - script-src 'self' 'unsafe-inline';style-src 'self' 'unsafe-inline' use.typekit.net
+        p.typekit.net pro.fontawesome.com;img-src 'self' https://cdn.1stdigital.com
+        data:;font-src 'self' use.typekit.net p.typekit.net pro.fontawesome.com;frame-ancestors
+        'self' https://backoffice.smarttrust.welton.ee https://portal.smarttrust.welton.ee
+        https://smarttrust.welton.ee;block-all-mixed-content
+      Feature-Policy:
+      - accelerometer 'none'; camera 'none'; geolocation 'none'; gyroscope 'none';
+        magnetometer 'none'; microphone 'none'; payment 'none'; usb 'none'
+      X-Powered-By:
+      - ASP.NET
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsImtpZCI6Ijc5QjU1NjRGNTIwRDQ1NzZDM0U4MzdCMjM1RTk2MTZGNDdFNjUzM0QiLCJ0eXAiOiJhdCtqd3QiLCJ4NXQiOiJlYlZXVDFJTlJYYkQ2RGV5TmVsaGIwZm1VejAifQ.eyJuYmYiOjE2MDIwMDUwNjYsImV4cCI6MTYwMjAwODY2NiwiaXNzIjoiaHR0cHM6Ly9hdXRoLnNtYXJ0dHJ1c3Qud2VsdG9uLmVlIiwiYXVkIjoiUGFydG5lckFwaSIsImNsaWVudF9pZCI6Imluay10ZXN0LWNsaWVudCIsImNsaWVudF9wYXJ0bmVyLmlkIjoiNyIsInNjb3BlIjpbIlBhcnRuZXJBcGkiXX0.Z-uaHcx1ZbButySRAZ0ryElFXthths3I7IRU5JMr7SCkXpdv75O5l34TCtR3fFLd01qupR8AKo9QR-8fH3XtI2PlqZzs89-7MFZAFCEoA2RCbCcsqy-UeXHErJz7ePUoSlpK9248WGNZecjdQcpUBSis7_mpZ7XFRayt5Qf2tStcEkuDs8yCH7dTuAbOz18iTEq6d4R4gjhq2GMaIIK85WbJT_4vELhTkAYrAoE4iKSIk65ValSm7c4bU-zuDzTZ-SMk_FHMnmWaKXjruHrVuGlITgM8dqFWwqeppWc2G7Uv4GzOUqv1_qx--i_AOQzjP1CcxQGqKIlVbgo16s06bYxueI9KheiouUOIxCqR0L00rMhZw-PqqgDl8H0cYCTLdERHynKw8bGTMEf2DlD9J8pisF5jG-KQwT0yYdOQXuGybCTJlyT-qZ0rA58quXCKW-OxscshwBfG1-UnYJ35mOynz80xFeHOjNI8DcFR2TOyrq4jjNyDCAayAf5Tloi4g-YfSWA3r-6ERPmert9wWJRsCWvag3iO0rQhDpHLGte-mvWzIgvWnFk5I9nfw0mTWrRwT5erR1juy2bGKB3c_DdKpVe8cA9u8uIEMRZwEn3kFL1Yej-2v4CvBF7VC4piy7tYS4-49x7smCRofaFxXsb08ObnH8-B8YIOjvG8Rco","expires_in":3600,"token_type":"Bearer","scope":"PartnerApi"}'
+  recorded_at: Tue, 06 Oct 2020 17:24:26 GMT
+- request:
+    method: post
+    uri: https://partner-api.smarttrust.welton.ee/instructions/deposits-fiat
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6Ijc5QjU1NjRGNTIwRDQ1NzZDM0U4MzdCMjM1RTk2MTZGNDdFNjUzM0QiLCJ0eXAiOiJhdCtqd3QiLCJ4NXQiOiJlYlZXVDFJTlJYYkQ2RGV5TmVsaGIwZm1VejAifQ.eyJuYmYiOjE2MDIwMDUwNjYsImV4cCI6MTYwMjAwODY2NiwiaXNzIjoiaHR0cHM6Ly9hdXRoLnNtYXJ0dHJ1c3Qud2VsdG9uLmVlIiwiYXVkIjoiUGFydG5lckFwaSIsImNsaWVudF9pZCI6Imluay10ZXN0LWNsaWVudCIsImNsaWVudF9wYXJ0bmVyLmlkIjoiNyIsInNjb3BlIjpbIlBhcnRuZXJBcGkiXX0.Z-uaHcx1ZbButySRAZ0ryElFXthths3I7IRU5JMr7SCkXpdv75O5l34TCtR3fFLd01qupR8AKo9QR-8fH3XtI2PlqZzs89-7MFZAFCEoA2RCbCcsqy-UeXHErJz7ePUoSlpK9248WGNZecjdQcpUBSis7_mpZ7XFRayt5Qf2tStcEkuDs8yCH7dTuAbOz18iTEq6d4R4gjhq2GMaIIK85WbJT_4vELhTkAYrAoE4iKSIk65ValSm7c4bU-zuDzTZ-SMk_FHMnmWaKXjruHrVuGlITgM8dqFWwqeppWc2G7Uv4GzOUqv1_qx--i_AOQzjP1CcxQGqKIlVbgo16s06bYxueI9KheiouUOIxCqR0L00rMhZw-PqqgDl8H0cYCTLdERHynKw8bGTMEf2DlD9J8pisF5jG-KQwT0yYdOQXuGybCTJlyT-qZ0rA58quXCKW-OxscshwBfG1-UnYJ35mOynz80xFeHOjNI8DcFR2TOyrq4jjNyDCAayAf5Tloi4g-YfSWA3r-6ERPmert9wWJRsCWvag3iO0rQhDpHLGte-mvWzIgvWnFk5I9nfw0mTWrRwT5erR1juy2bGKB3c_DdKpVe8cA9u8uIEMRZwEn3kFL1Yej-2v4CvBF7VC4piy7tYS4-49x7smCRofaFxXsb08ObnH8-B8YIOjvG8Rco
+      Content-Length:
+      - '0'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 500
+      message: Internal Server Error
+    headers:
+      Date:
+      - Tue, 06 Oct 2020 17:24:27 GMT
+      Content-Type:
+      - application/problem+json; charset=utf-8
+      Content-Length:
+      - '124'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      Server:
+      - Microsoft-IIS/10.0
+      X-Powered-By:
+      - ASP.NET
+    body:
+      encoding: UTF-8
+      string: '{"type":"https://httpstatuses.com/500","title":"Internal Server Error","status":500,"traceId":"|a7474855-46274ce64d9fb4de."}'
+  recorded_at: Tue, 06 Oct 2020 17:24:27 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/LegacyTrustInstructionFiatDeposit/Create/WhenValidParams/Result/has_attributes.yml
+++ b/spec/fixtures/vcr_cassettes/LegacyTrustInstructionFiatDeposit/Create/WhenValidParams/Result/has_attributes.yml
@@ -1,0 +1,105 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://auth.smarttrust.welton.ee/connect/token
+    body:
+      encoding: UTF-8
+      string: client_id=config_env['OAUTH_CLIENT_ID']&client_secret=config_env['OAUTH_CLIENT_SECRET']&grant_type=client_credentials&scope=PartnerApi
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 06 Oct 2020 18:34:39 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - 13config_env['GLOBAL_CLIENT_ID']
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-store, no-cache, max-age=0
+      Pragma:
+      - no-cache
+      Vary:
+      - Accept-Encoding
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - script-src 'self' 'unsafe-inline';style-src 'self' 'unsafe-inline' use.typekit.net
+        p.typekit.net pro.fontawesome.com;img-src 'self' https://cdn.1stdigital.com
+        data:;font-src 'self' use.typekit.net p.typekit.net pro.fontawesome.com;frame-ancestors
+        'self' https://backoffice.smarttrust.welton.ee https://portal.smarttrust.welton.ee
+        https://smarttrust.welton.ee;block-all-mixed-content
+      Feature-Policy:
+      - accelerometer 'none'; camera 'none'; geolocation 'none'; gyroscope 'none';
+        magnetometer 'none'; microphone 'none'; payment 'none'; usb 'none'
+      X-Powered-By:
+      - ASP.NET
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsImtpZCI6Ijc5QjU1NjRGNTIwRDQ1NzZDM0U4MzdCMjM1RTk2MTZGNDdFNjUzM0QiLCJ0eXAiOiJhdCtqd3QiLCJ4NXQiOiJlYlZXVDFJTlJYYkQ2RGV5TmVsaGIwZm1VejAifQ.eyJuYmYiOjE2MDIwMDkyNzksImV4cCI6MTYwMjAxMjg3OSwiaXNzIjoiaHR0cHM6Ly9hdXRoLnNtYXJ0dHJ1c3Qud2VsdG9uLmVlIiwiYXVkIjoiUGFydG5lckFwaSIsImNsaWVudF9pZCI6Imluay10ZXN0LWNsaWVudCIsImNsaWVudF9wYXJ0bmVyLmlkIjoiNyIsInNjb3BlIjpbIlBhcnRuZXJBcGkiXX0.RpfzMwSCQvRODntnpRHy7qAQ_DxB9_vZNZZqv8dMVig6x4vnzIZMvAkzdOpO_Li4TRA_u0yfVGqt5ntp1XJjdkCuY0sYOGTxmV15SPmtEQRNd7CJFMV-Okn7Tg4q2mpAYr_iskf1nfZinFKflM2WOUCNLdak9d7ubFWhvlSV_vGVduDw7iNGOChn-IiivP4bunE-R795gvs5EMOFGXpuaXDhrXxDnACvuv6JLVm29qNI_gAK6xkIDazqnJ8Tm5vz7TGUdFIZOebjFDDTE4qdq5_pqOXcB_FbW-f9f5WYZ1XQGn7OPidfFZENXucITxueszTWO5pAtA1-IfasN7cKePwtBWHFBrdABNJbceMRkZkIB_RZPVD6FCHPSPpbd6Qxxvw1QWDq-FGly0ScxdihDMJTnaF2N6n-hKyrBl61Huree7V6gbl5tE5DiXDRiOSRhnrMXZJxuFxDk33AerllAkoEhrhvWYLW060S-rCVJdrZjFOlfYPJViDDSCoEnF3vUicAus1MqTWHMCX9Z0LTOJaqmygBxsnJBmRQBqnw5LwtFWscM-G2Qu2XFVYFzxm1ASjMALk7guGqWuYUCDybaeAEPABSf1nB3vQ24oed1C8A29vWmw102xRcEdN4alzw5OXqI3URyAnmciiUYWZkMby8NJJjrclw2dUAQfnEmCA","expires_in":3600,"token_type":"Bearer","scope":"PartnerApi"}'
+  recorded_at: Tue, 06 Oct 2020 18:34:40 GMT
+- request:
+    method: post
+    uri: https://partner-api.smarttrust.welton.ee/instructions/deposits-fiat
+    body:
+      encoding: UTF-8
+      string: '{"serviceAccountId":config_env[''GLOBAL_SERVICE_ACCOUNT_ID''],"clientBankAccountId":36,"amount":100.5}'
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+      Content-Type:
+      - application/json
+      Clientid:
+      - config_env['GLOBAL_CLIENT_ID']
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6Ijc5QjU1NjRGNTIwRDQ1NzZDM0U4MzdCMjM1RTk2MTZGNDdFNjUzM0QiLCJ0eXAiOiJhdCtqd3QiLCJ4NXQiOiJlYlZXVDFJTlJYYkQ2RGV5TmVsaGIwZm1VejAifQ.eyJuYmYiOjE2MDIwMDkyNzksImV4cCI6MTYwMjAxMjg3OSwiaXNzIjoiaHR0cHM6Ly9hdXRoLnNtYXJ0dHJ1c3Qud2VsdG9uLmVlIiwiYXVkIjoiUGFydG5lckFwaSIsImNsaWVudF9pZCI6Imluay10ZXN0LWNsaWVudCIsImNsaWVudF9wYXJ0bmVyLmlkIjoiNyIsInNjb3BlIjpbIlBhcnRuZXJBcGkiXX0.RpfzMwSCQvRODntnpRHy7qAQ_DxB9_vZNZZqv8dMVig6x4vnzIZMvAkzdOpO_Li4TRA_u0yfVGqt5ntp1XJjdkCuY0sYOGTxmV15SPmtEQRNd7CJFMV-Okn7Tg4q2mpAYr_iskf1nfZinFKflM2WOUCNLdak9d7ubFWhvlSV_vGVduDw7iNGOChn-IiivP4bunE-R795gvs5EMOFGXpuaXDhrXxDnACvuv6JLVm29qNI_gAK6xkIDazqnJ8Tm5vz7TGUdFIZOebjFDDTE4qdq5_pqOXcB_FbW-f9f5WYZ1XQGn7OPidfFZENXucITxueszTWO5pAtA1-IfasN7cKePwtBWHFBrdABNJbceMRkZkIB_RZPVD6FCHPSPpbd6Qxxvw1QWDq-FGly0ScxdihDMJTnaF2N6n-hKyrBl61Huree7V6gbl5tE5DiXDRiOSRhnrMXZJxuFxDk33AerllAkoEhrhvWYLW060S-rCVJdrZjFOlfYPJViDDSCoEnF3vUicAus1MqTWHMCX9Z0LTOJaqmygBxsnJBmRQBqnw5LwtFWscM-G2Qu2XFVYFzxm1ASjMALk7guGqWuYUCDybaeAEPABSf1nB3vQ24oed1C8A29vWmw102xRcEdN4alzw5OXqI3URyAnmciiUYWZkMby8NJJjrclw2dUAQfnEmCA
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 06 Oct 2020 18:34:40 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      Server:
+      - Microsoft-IIS/10.0
+      X-Powered-By:
+      - ASP.NET
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":56,"dateCreated":"2020-10-06T18:34:40.51896Z","referenceNumber":"CMR-Y31NY2","bankName":"MBANK
+        S.A. (FORMERLY BRE BANK S.A.)","bankAccountNumber":" 271140200400003702412029config_env[''GLOBAL_SERVICE_ACCOUNT_ID'']","packageName":"Complete
+        Custody","serviceAccountNumber":"10200000config_env[''GLOBAL_SERVICE_ACCOUNT_ID'']17","serviceAccountName":"Service
+        Account","amount":100.5,"currency":"BTC","supportingDocumentS3Key":null,"status":"Initiated","transferType":"Deposit"}'
+  recorded_at: Tue, 06 Oct 2020 18:34:40 GMT
+recorded_with: VCR 6.0.0

--- a/spec/fixtures/vcr_cassettes/LegacyTrustInstructionFiatDeposit/Create/WhenValidParams/returns_result.yml
+++ b/spec/fixtures/vcr_cassettes/LegacyTrustInstructionFiatDeposit/Create/WhenValidParams/returns_result.yml
@@ -1,0 +1,105 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://auth.smarttrust.welton.ee/connect/token
+    body:
+      encoding: UTF-8
+      string: client_id=config_env['OAUTH_CLIENT_ID']&client_secret=config_env['OAUTH_CLIENT_SECRET']&grant_type=client_credentials&scope=PartnerApi
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 06 Oct 2020 18:27:57 GMT
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '1339'
+      Connection:
+      - keep-alive
+      Cache-Control:
+      - no-store, no-cache, max-age=0
+      Pragma:
+      - no-cache
+      Vary:
+      - Accept-Encoding
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Xss-Protection:
+      - 1; mode=block
+      Content-Security-Policy:
+      - script-src 'self' 'unsafe-inline';style-src 'self' 'unsafe-inline' use.typekit.net
+        p.typekit.net pro.fontawesome.com;img-src 'self' https://cdn.1stdigital.com
+        data:;font-src 'self' use.typekit.net p.typekit.net pro.fontawesome.com;frame-ancestors
+        'self' https://backoffice.smarttrust.welton.ee https://portal.smarttrust.welton.ee
+        https://smarttrust.welton.ee;block-all-mixed-content
+      Feature-Policy:
+      - accelerometer 'none'; camera 'none'; geolocation 'none'; gyroscope 'none';
+        magnetometer 'none'; microphone 'none'; payment 'none'; usb 'none'
+      X-Powered-By:
+      - ASP.NET
+    body:
+      encoding: ASCII-8BIT
+      string: '{"access_token":"eyJhbGciOiJSUzI1NiIsImtpZCI6Ijc5QjU1NjRGNTIwRDQ1NzZDM0U4MzdCMjM1RTk2MTZGNDdFNjUzM0QiLCJ0eXAiOiJhdCtqd3QiLCJ4NXQiOiJlYlZXVDFJTlJYYkQ2RGV5TmVsaGIwZm1VejAifQ.eyJuYmYiOjE2MDIwMDg4NzcsImV4cCI6MTYwMjAxMjQ3NywiaXNzIjoiaHR0cHM6Ly9hdXRoLnNtYXJ0dHJ1c3Qud2VsdG9uLmVlIiwiYXVkIjoiUGFydG5lckFwaSIsImNsaWVudF9pZCI6Imluay10ZXN0LWNsaWVudCIsImNsaWVudF9wYXJ0bmVyLmlkIjoiNyIsInNjb3BlIjpbIlBhcnRuZXJBcGkiXX0.WGv1Tjy5VxTOBERgCzp_LX5eg0wDzBSu424XPpoN-mkQo8WwtyPO_bc5ryLcVFzmmA4GYPBP6PtBJuwjMhweZUVHBS4kd9W81s3qN8wuTE1bDuJKDY0l3mYQsiQbCc1p_8CP6u4DVeIBGL-i6bOIiNTd4HebzWWGqK-dX_aiWdpKAgizofJqyvt-yvYQt90trXI3Ngm9gYVUverZgFpeJGTvjCDFX_bhyvN7Fj5IzBMC7lC5_doBJ5WURFk2zsKczYx-vvj4oPmdOgZZLPV180SfkOIBu-SN2zeR4_ET0wly4CRZhdd7MLQvE7PTI7Yaxc3aPE_Y00_uXg34YmUvu-hNHxG4YdOkBsNCZ7yiCzLtcVg_9ihNGGYIPNCQAQK0Q3V0uI5aJUQAdXuQKQcGQueTsad2GSRdxLSAtFpIbKR7C5pPL62sTHclG6uCmhlDeQtFjG2KFNe0cPH7kptMSIZF5WiIYMdi_1BgNLiOXJcvqqVbhMNC9KgQpHuGb_VFhEvpFAiJfwBw1GcBxa-rL0JddgzfKuIbtUQMumCqZ5ZvwRx-Zc1iyqDqlcnhhkgkRGHpLMm9ZBfG6eJ9xOq48Hxp8kLzDC1zpCJd5aVZmbWlIxGJnNqbSelRtdu-UHZR9We0zxyKWDyzmOR02p5bUORLX2w4Cnjd3ehKD9SJJCI","expires_in":3600,"token_type":"Bearer","scope":"PartnerApi"}'
+  recorded_at: Tue, 06 Oct 2020 18:27:57 GMT
+- request:
+    method: post
+    uri: https://partner-api.smarttrust.welton.ee/instructions/deposits-fiat
+    body:
+      encoding: UTF-8
+      string: '{"serviceAccountId":config_env[''GLOBAL_SERVICE_ACCOUNT_ID''],"clientBankAccountId":36,"amount":100.5}'
+    headers:
+      User-Agent:
+      - Faraday v1.0.1
+      Content-Type:
+      - application/json
+      Clientid:
+      - config_env['GLOBAL_CLIENT_ID']
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6Ijc5QjU1NjRGNTIwRDQ1NzZDM0U4MzdCMjM1RTk2MTZGNDdFNjUzM0QiLCJ0eXAiOiJhdCtqd3QiLCJ4NXQiOiJlYlZXVDFJTlJYYkQ2RGV5TmVsaGIwZm1VejAifQ.eyJuYmYiOjE2MDIwMDg4NzcsImV4cCI6MTYwMjAxMjQ3NywiaXNzIjoiaHR0cHM6Ly9hdXRoLnNtYXJ0dHJ1c3Qud2VsdG9uLmVlIiwiYXVkIjoiUGFydG5lckFwaSIsImNsaWVudF9pZCI6Imluay10ZXN0LWNsaWVudCIsImNsaWVudF9wYXJ0bmVyLmlkIjoiNyIsInNjb3BlIjpbIlBhcnRuZXJBcGkiXX0.WGv1Tjy5VxTOBERgCzp_LX5eg0wDzBSu424XPpoN-mkQo8WwtyPO_bc5ryLcVFzmmA4GYPBP6PtBJuwjMhweZUVHBS4kd9W81s3qN8wuTE1bDuJKDY0l3mYQsiQbCc1p_8CP6u4DVeIBGL-i6bOIiNTd4HebzWWGqK-dX_aiWdpKAgizofJqyvt-yvYQt90trXI3Ngm9gYVUverZgFpeJGTvjCDFX_bhyvN7Fj5IzBMC7lC5_doBJ5WURFk2zsKczYx-vvj4oPmdOgZZLPV180SfkOIBu-SN2zeR4_ET0wly4CRZhdd7MLQvE7PTI7Yaxc3aPE_Y00_uXg34YmUvu-hNHxG4YdOkBsNCZ7yiCzLtcVg_9ihNGGYIPNCQAQK0Q3V0uI5aJUQAdXuQKQcGQueTsad2GSRdxLSAtFpIbKR7C5pPL62sTHclG6uCmhlDeQtFjG2KFNe0cPH7kptMSIZF5WiIYMdi_1BgNLiOXJcvqqVbhMNC9KgQpHuGb_VFhEvpFAiJfwBw1GcBxa-rL0JddgzfKuIbtUQMumCqZ5ZvwRx-Zc1iyqDqlcnhhkgkRGHpLMm9ZBfG6eJ9xOq48Hxp8kLzDC1zpCJd5aVZmbWlIxGJnNqbSelRtdu-UHZR9We0zxyKWDyzmOR02p5bUORLX2w4Cnjd3ehKD9SJJCI
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 06 Oct 2020 18:27:58 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '405'
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      Server:
+      - Microsoft-IIS/10.0
+      X-Powered-By:
+      - ASP.NET
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":55,"dateCreated":"2020-10-06T18:27:58.067332Z","referenceNumber":"CMR-VMEFVG","bankName":"MBANK
+        S.A. (FORMERLY BRE BANK S.A.)","bankAccountNumber":" 271140200400003702412029config_env[''GLOBAL_SERVICE_ACCOUNT_ID'']","packageName":"Complete
+        Custody","serviceAccountNumber":"10200000config_env[''GLOBAL_SERVICE_ACCOUNT_ID'']17","serviceAccountName":"Service
+        Account","amount":100.5,"currency":"BTC","supportingDocumentS3Key":null,"status":"Initiated","transferType":"Deposit"}'
+  recorded_at: Tue, 06 Oct 2020 18:27:58 GMT
+recorded_with: VCR 6.0.0

--- a/spec/legacy_trust/instruction/fiat_deposit_spec.rb
+++ b/spec/legacy_trust/instruction/fiat_deposit_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe LegacyTrust::Instruction::FiatDeposit, vcr: true do
+  describe '.create' do
+    subject(:method_execution) { described_class.create(**opts) }
+
+    context 'when invalid params' do
+      let(:opts) { {} }
+
+      it_behaves_like 'invalid API setup'
+
+      it 'raises error' do
+        expect { method_execution }.to raise_error(LegacyTrust::RequestError)
+      end
+    end
+
+    context 'when valid params' do
+      let(:opts) { { body: { client_bank_account_id: 36, amount: 100.5 } } }
+
+      it_behaves_like 'invalid API setup'
+
+      it 'returns result' do
+        expect(method_execution).to be_a(LegacyTrust::Result)
+      end
+
+      describe 'result' do
+        it 'has attributes' do
+          expect(method_execution.body.keys).to contain_exactly(
+            :id, :date_created, :reference_number, :bank_name, :bank_account_number, :package_name,
+            :service_account_number, :service_account_name, :amount, :currency,
+            :supporting_document_s3_key, :status, :transfer_type
+          )
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,8 +8,10 @@ require 'support/shared_examples'
 
 # Setup OAuth2 authentication credentials - config/config.yml
 config_env = YAML.load_file(File.join(__dir__, '..', 'config', 'config.yml'))
-LegacyTrust.client_id = config_env['CLIENT_ID']
-LegacyTrust.client_secret = config_env['CLIENT_SECRET']
+LegacyTrust.oauth_client_id = config_env['OAUTH_CLIENT_ID']
+LegacyTrust.oauth_client_secret = config_env['OAUTH_CLIENT_SECRET']
+LegacyTrust.global_client_id = config_env['GLOBAL_CLIENT_ID']
+LegacyTrust.global_service_account_id = config_env['GLOBAL_SERVICE_ACCOUNT_ID']
 
 VCR.configure do |config|
   config.cassette_library_dir = 'spec/fixtures/vcr_cassettes'

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.shared_examples_for 'invalid API setup' do
-  before { allow(LegacyTrust).to receive(:client_id).and_return(nil) }
+  before { allow(LegacyTrust).to receive(:oauth_client_id).and_return(nil) }
 
   it 'raises error' do
     expect { method_execution }.to raise_error(LegacyTrust::SetupError)


### PR DESCRIPTION
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Add here link to Jira, but let this not be the only content in this section -->
**[JIRA ticket](https://banktothefuture.atlassian.net/browse/AT-3730)**

FiatDeposit creation endpoint is needed to get bank account credentials, so the user is able to make a deposit base on them.

## Description
<!--- Describe what you have done and why have you done it this way -->

- introducing global API attributes (client_id, service_account_id)
- new method `LegacyTrust::Instruction::FiatDeposit.create`

## Screenshots (if appropriate):

All tests passed.
![image](https://user-images.githubusercontent.com/2733755/95254817-c4e13000-0820-11eb-9755-90d4e58a8fc2.png)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Having a ruby console opened, I was executing that endpoint in many scenarios.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have added tests to cover my changes.
- [ ] I have added feature flags to hide new changes on production
- [ ] I have tested if data is not visible by other user (through modified API call, or URL change)
- [ ] I have tested what happens if I resubmit form or API call few times
- [ ] I have tested inputs against tricky strings like `<script>alert('XSS')</script>` or emojis 🐛😺
